### PR TITLE
Task: declare logger parameter of client optional

### DIFF
--- a/Classes/Akamai/Client.php
+++ b/Classes/Akamai/Client.php
@@ -37,7 +37,7 @@ final class Client
         protected ?RestrictedDirectory $restrictedDirectory = null,
         protected ?Proxy $proxy = null,
         protected ?Path $workingDirectory = null,
-        protected ?LoggerInterface $logger
+        protected ?LoggerInterface $logger = null
     ) {
     }
 


### PR DESCRIPTION
To avoid warnings in php 8.1 and errors in php 8.2